### PR TITLE
🐛 Fix resume of contentvideo when native hls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "1.1.4",
+ "version": "1.1.5",
  "name": "@stroeer/stroeer-videoplayer-ivad-plugin",
  "description": "Ströer Videoplayer Interactive Video Ads Plugin",
  "main": "dist/StroeerVideoplayer-ivad-plugin.cjs.js",

--- a/src/VASTParser.ts
+++ b/src/VASTParser.ts
@@ -385,7 +385,9 @@ class VASTParser {
           this.videoEl.load()
           svp.setSrc(this._originalVideoSource)
           svp.loadStreamSource()
-          svp.getHls().startLoad()
+          if (svp.getHls() !== null) {
+            svp.getHls().startLoad()
+          }
           this.videoEl.load()
           // this seems to fix a bug in safari,
           // where the video is not playing correctly after the ad is finished
@@ -467,7 +469,9 @@ class VASTParser {
         svp.setContentVideo()
         svp.setSrc(this._originalVideoSource)
         svp.loadStreamSource()
-        svp.getHls().startLoad()
+        if (svp.getHls() !== null) {
+          svp.getHls().startLoad()
+        }
         // eslint-disable-next-line
         this.videoEl.play()
       }

--- a/src/VPAIDUtils.js
+++ b/src/VPAIDUtils.js
@@ -148,7 +148,9 @@ function CreateIframe (url, currentAd, stroeervideoplayer, vastparser, opts, omi
         videoEl.load()
         svp.setSrc(vastparser._originalVideoSource)
         svp.loadStreamSource()
-        svp.getHls().startLoad()
+        if (svp.getHls() !== null) {
+          svp.getHls().startLoad()
+        }
         videoEl.load()
         // this seems to fix a bug in safari,
         // where the video is not playing correctly after the ad is finished


### PR DESCRIPTION
When the browser can natively play the hls stream, the player does not initialize the hls.js library and therefore `player.getHls()` is `null` which resulted in
a JavaScript error when accessing `player.getHls().startLoad()` directly and prevented the further execution of the js.

This caused the player to not resume the contentvideo. This should be fixed now.